### PR TITLE
Memleak fix

### DIFF
--- a/decoder/rec_eng_recipe.py
+++ b/decoder/rec_eng_recipe.py
@@ -92,15 +92,16 @@ if lna_path[-1] != '/':
 t = Decoder.Toolbox()
 
 t.select_decoder(0)
-t.set_optional_short_silence(1)
-t.set_cross_word_triphones(1)
-t.set_require_sentence_end(1)
-t.set_silence_is_word(0)
-
 sys.stderr.write("loading models\n")
 t.hmm_read(hmms)
 t.duration_read(dur)
 #t.sr_read(sr_model)
+t.reinitialize_search()
+
+t.set_optional_short_silence(1)
+t.set_cross_word_triphones(1)
+t.set_require_sentence_end(1)
+t.set_silence_is_word(0)
 
 t.set_verbose(1)
 t.set_print_text_result(1)

--- a/decoder/rec_file.py
+++ b/decoder/rec_file.py
@@ -62,15 +62,17 @@ os.system(akupath + "/phone_probs -b "+akumodel+" -c "+akumodel+".cfg -r "+tempp
 t = Decoder.Toolbox()
 
 t.select_decoder(0)
+sys.stderr.write("loading models\n")
+t.hmm_read(hmms)
+t.duration_read(dur)
+t.reinitialize_search()
+
 t.set_optional_short_silence(1)
 
 t.set_cross_word_triphones(1)
 
 t.set_require_sentence_end(1)
 
-sys.stderr.write("loading models\n")
-t.hmm_read(hmms)
-t.duration_read(dur)
 
 t.set_verbose(1)
 t.set_print_text_result(1)

--- a/decoder/rec_hammaspuhe.py
+++ b/decoder/rec_hammaspuhe.py
@@ -218,6 +218,10 @@ recipe_file.close()
 t = Decoder.Toolbox()
 
 t.select_decoder(0)
+print "Loading acoustic model."
+t.hmm_read(hmms)
+t.duration_read(dur)
+t.reinitialize_search()
 
 if morph_model:
 	t.set_silence_is_word(1)
@@ -228,10 +232,6 @@ t.set_optional_short_silence(1)
 
 t.set_cross_word_triphones(1)
 t.set_require_sentence_end(1)
-
-print "Loading acoustic model."
-t.hmm_read(hmms)
-t.duration_read(dur)
 
 t.set_verbose(1)
 t.set_print_text_result(0)

--- a/decoder/rec_recipe.py
+++ b/decoder/rec_recipe.py
@@ -92,16 +92,17 @@ if lna_path[-1] != '/':
 t = Decoder.Toolbox()
 
 t.select_decoder(0)
+sys.stderr.write("loading models\n")
+t.hmm_read(hmms)
+t.duration_read(dur)
+#t.sr_read(sr_model)
+t.reinitialize_search()
+
 t.set_optional_short_silence(1)
 
 t.set_cross_word_triphones(1)
 
 t.set_require_sentence_end(1)
-
-sys.stderr.write("loading models\n")
-t.hmm_read(hmms)
-t.duration_read(dur)
-#t.sr_read(sr_model)
 
 t.set_verbose(1)
 t.set_print_text_result(1)

--- a/decoder/rec_recipe2.py
+++ b/decoder/rec_recipe2.py
@@ -95,16 +95,17 @@ if lna_path[-1] != '/':
 t = Decoder.Toolbox()
 
 t.select_decoder(0)
+sys.stderr.write("loading models\n")
+t.hmm_read(hmms)
+t.duration_read(dur)
+#t.sr_read(sr_model)
+t.reinitialize_search()
+
 t.set_optional_short_silence(1)
 
 t.set_cross_word_triphones(1)
 
 t.set_require_sentence_end(1)
-
-sys.stderr.write("loading models\n")
-t.hmm_read(hmms)
-t.duration_read(dur)
-#t.sr_read(sr_model)
 
 t.set_verbose(1)
 t.set_print_text_result(1)

--- a/decoder/src/Expander.cc
+++ b/decoder/src/Expander.cc
@@ -16,10 +16,10 @@ struct TokenCompare {
 };
 
 
-Expander::Expander(const std::vector<Hmm> &hmms, Lexicon &lexicon,
+Expander::Expander(const std::vector<Hmm> &hmms,
 		   Acoustics &acoustics)
   : m_hmms(hmms),
-    m_lexicon(lexicon),
+    m_lexicon(NULL),
     m_acoustics(acoustics),
 
     m_forced_end(false),
@@ -476,7 +476,7 @@ Expander::clear_tokens()
 void
 Expander::create_initial_tokens(int start_frame)
 {
-  Lexicon::Node *node = m_lexicon.root();
+  Lexicon::Node *node = m_lexicon->root();
   Lexicon::Token *token;
   
   for (int next_id = 0; next_id < node->next.size(); next_id++) {
@@ -562,12 +562,12 @@ Expander::debug_print_tokens()
 void
 Expander::expand(int start_frame, int frames)
 {
-  if (m_words.size() != m_lexicon.words()) {
+  if (m_words.size() != m_lexicon->words()) {
     // Changing lexicon size is not supported at the moment
     assert(m_words.size() == 0);
     m_active_words.clear();
-    m_active_words.reserve(m_lexicon.words());
-    m_words.resize(m_lexicon.words());
+    m_active_words.reserve(m_lexicon->words());
+    m_words.resize(m_lexicon->words());
     for (int i = 0; i < m_words.size(); i++)
       m_words[i].word_id = i;
   }

--- a/decoder/src/Expander.hh
+++ b/decoder/src/Expander.hh
@@ -41,7 +41,7 @@ public:
   };
 
   // Actions
-  Expander(const std::vector<Hmm> &hmms, Lexicon &lexicon,
+  Expander(const std::vector<Hmm> &hmms,
 	   Acoustics &m_acoustics);
 
   ~Expander();
@@ -66,6 +66,7 @@ public:
 
   void set_post_durations(bool durations) { m_post_durations = durations; }
   void set_rabiner_post_mode(int mode) { m_rabiner_post_mode = mode; }
+  void set_lexicon(Lexicon *l) {m_lexicon = l;}
 
   // Info
   inline std::vector<Lexicon::Token*> &tokens() { return m_tokens; }
@@ -109,7 +110,7 @@ private:
   void release_token(Lexicon::Token *token);
   
   const std::vector<Hmm> &m_hmms;
-  Lexicon &m_lexicon;
+  Lexicon *m_lexicon;
   Acoustics &m_acoustics;
 
   // Options

--- a/decoder/src/HashCache.hh
+++ b/decoder/src/HashCache.hh
@@ -8,12 +8,14 @@ template <typename T>
 class HashCache {
 public:
   HashCache(void);
+  ~HashCache();
   inline bool insert(int key, T item, T *removed);
   inline bool find(int key, T *result);
   void set_max_items(int max);
   int get_num_items(void) { return num_items; }
   bool remove_last_item(T *removed);
   bool remove_item(int key, T *removed);
+  void clear_cache();
 
 private:
   void rehash(int new_max);
@@ -46,9 +48,29 @@ HashCache<T>::HashCache(void)
 }
 
 template<typename T>
+void HashCache<T>::clear_cache(void) {
+  for (int i=0; i<max_num_items; i++) {
+    StoreType *cur = hash_table[i];
+    while(cur) {
+      StoreType *prev = cur;
+      cur = cur->hash_list_next;
+      delete prev->value;
+      delete prev;
+    }
+  }
+}
+
+template<typename T>
+HashCache<T>::~HashCache(void)
+{
+  clear_cache();
+}
+
+template<typename T>
 void
 HashCache<T>::rehash(int new_max)
 {
+  clear_cache();
   hash_table.resize(new_max);
   for (int i = 0; i < new_max; i++)
     hash_table[i] = NULL;

--- a/decoder/src/LMHistory.hh
+++ b/decoder/src/LMHistory.hh
@@ -174,11 +174,12 @@ public:
 #endif
   };
 
-  LMHistory(const Word & last_word, LMHistory * previous);
+  LMHistory(const Word * last_word, LMHistory * previous);
+  LMHistory();
 
   const Word & last() const
   {
-    return m_last_word;
+    return *last_word;
   }
 
   ConstReverseIterator rbegin() const;
@@ -191,18 +192,22 @@ public:
   int word_start_frame;
   int word_first_silence_frame;  // "end frame", initialized to -1.
 
-private:
   // A reference to TokenPassSearch::m_word_lookup table.
-  const Word & m_last_word;
+  const Word * last_word;
 };
 
-inline LMHistory::LMHistory(const Word & last_word, LMHistory * previous) :
+inline LMHistory::LMHistory(const Word * last_word, LMHistory * previous) :
   previous(previous), reference_count(0), printed(false), word_start_frame(
-									   0), word_first_silence_frame(-1), m_last_word(last_word)
+									   0), word_first_silence_frame(-1), last_word(last_word)
 {
   if (previous)
     hist::link(previous);
 }
+
+inline LMHistory::LMHistory() :
+  previous(NULL), reference_count(0), printed(false), word_start_frame(0), 
+  word_first_silence_frame(-1), last_word(NULL)
+{}
 
 inline LMHistory::ConstReverseIterator &
 LMHistory::ConstReverseIterator::operator++()

--- a/decoder/src/TPLexPrefixTree.cc
+++ b/decoder/src/TPLexPrefixTree.cc
@@ -661,7 +661,7 @@ TPLexPrefixTree::post_process_fan_triphone(Node *node,
       else
       {
         // Node was removed
-        node->arcs.erase(arc_it);
+        arc_it = node->arcs.erase(arc_it);
       }
     }
     else

--- a/decoder/src/TPLexPrefixTree.hh
+++ b/decoder/src/TPLexPrefixTree.hh
@@ -128,17 +128,43 @@ public:
 
     unsigned char depth;
     unsigned char dur;
+
+    Token():
+      node(NULL),
+      next_node_token(NULL),
+      am_log_prob(0.0f),
+      lm_log_prob(0.0f),
+      cur_am_log_prob(0.0f),
+      cur_lm_log_prob(0.0f),
+      total_log_prob(0.0f),
+      lm_history(NULL),
+      lm_hist_code(0),
+      fsa_lm_node(0),
+      recent_word_graph_node(0),
+      word_history(NULL),
+      word_start_frame(0),
+      word_count(0),
+      state_history(NULL),
+      depth(0),
+      dur(0)
+    { }
   };
+
 
   class Arc {
   public:
     float log_prob;
     Node *next;
+
+    Arc():
+      log_prob(0.0f),
+      next(NULL)
+    {}
   };
 
   class Node {
   public:
-    inline Node() : word_id(-1), state(NULL), token_list(NULL), flags(NODE_NORMAL) { }
+    inline Node() : word_id(-1), node_id(0), state(NULL), token_list(NULL), flags(NODE_NORMAL) { }
     inline Node(int wid) : word_id(wid), state(NULL), token_list(NULL), flags(NODE_NORMAL) { }
     inline Node(int wid, HmmState *s) : word_id(wid), state(s), token_list(NULL), flags(NODE_NORMAL) { }
     int word_id; // -1 for nodes without word identity.
@@ -156,6 +182,10 @@ public:
   struct NodeArcId {
     Node *node;
     int arc_index;
+    NodeArcId() :
+      node(NULL),
+      arc_index(0)
+    {}
   };
 
   TPLexPrefixTree(std::map<std::string,int> &hmm_map, std::vector<Hmm> &hmms);
@@ -406,7 +436,7 @@ private:
 TPLexPrefixTree::WordHistory::WordHistory(int word_id, int end_frame, 
 					  WordHistory *previous)
   : word_id(word_id), end_frame(end_frame), 
-    lm_log_prob(0), am_log_prob(0), cum_lm_log_prob(0), cum_am_log_prob(0),
+    lex_node_id(0), graph_node_id(0), lm_log_prob(0), am_log_prob(0), cum_lm_log_prob(0), cum_am_log_prob(0),
     printed(false), previous(previous), reference_count(0)
 {
   if (previous) {

--- a/decoder/src/TokenPassSearch.cc
+++ b/decoder/src/TokenPassSearch.cc
@@ -2251,6 +2251,10 @@ TokenPassSearch::acquire_lmhist(const LMHistory::Word * last_word, LMHistory * p
   m_lmh_pool.pop_back();
   lmh->last_word = last_word;
   lmh->previous = previous;
+  lmh->reference_count = 0;
+  lmh->printed = false;
+  lmh->word_start_frame = 0;
+  lmh->word_first_silence_frame=-1;
   if (previous) hist::link(lmh->previous);
   return lmh;
 }
@@ -2270,10 +2274,6 @@ void TokenPassSearch::release_token(TPLexPrefixTree::Token *token)
 void TokenPassSearch::release_lmhist(LMHistory *lmhist) {
   lmhist->last_word=NULL;
   lmhist->previous=NULL;
-  lmhist->reference_count = 0;
-  lmhist->printed = false;
-  lmhist->word_start_frame = 0;
-  lmhist->word_first_silence_frame=-1;
   m_lmh_pool.push_back(lmhist);
 }
 

--- a/decoder/src/TokenPassSearch.cc
+++ b/decoder/src/TokenPassSearch.cc
@@ -41,49 +41,75 @@ TokenPassSearch::TokenPassSearch(TPLexPrefixTree &lex, Vocabulary &vocab,
 #ifdef ENABLE_WORDCLASS_SUPPORT
   m_word_classes(NULL),
 #endif
-  m_acoustics(acoustics)
+  m_acoustics(acoustics),
+  m_end_frame(-1),
+  m_frame(0),
+  m_best_log_prob(0),
+  m_worst_log_prob(0),
+  m_best_we_log_prob(0),
+  m_best_final_token(NULL),
+  m_ngram(NULL),
+  m_fsa_lm(NULL),
+  m_lookahead_ngram(NULL),
+  m_print_probs(0),
+  m_print_text_result(0),
+  m_print_state_segmentation(false),
+  m_keep_state_segmentation(false),
+  m_global_beam(1e10),
+  m_word_end_beam(1e10),
+  m_similar_lm_hist_span(0),
+  m_lm_scale(1),
+  m_duration_scale(0),
+  m_transition_scale(1),
+  m_max_num_tokens(0),
+  m_verbose(0),
+  m_word_boundary_id(0),
+  m_lm_lookahead(0),
+  m_max_lookahead_score_list_size(DEFAULT_MAX_LOOKAHEAD_SCORE_LIST_SIZE),
+  m_max_node_lookahead_buffer_size(DEFAULT_MAX_NODE_LOOKAHEAD_BUFFER_SIZE),
+  m_insertion_penalty(0),
+  m_sentence_start_id(-1),
+  m_sentence_end_id(-1),
+  m_use_sentence_boundary(false),
+  m_generate_word_graph(false),
+  m_require_sentence_end(false),
+  m_remove_pronunciation_id(false),
+  m_use_word_pair_approximation(false),
+  m_use_lm_cache(true),
+  m_current_glob_beam(0),
+  m_current_we_beam(0),
+  m_eq_depth_beam(1e10),
+  m_eq_wc_beam(1e10),
+  m_fan_in_beam(1e10),
+  m_fan_out_beam(1e10),
+  m_state_beam(1e10),
+  filecount(0),
+  m_min_word_count(0),
+  m_fan_in_log_prob(0),
+  m_fan_out_log_prob(0),
+  m_fan_out_last_log_prob(0),
+  m_lm_lookahead_initialized(false)
 {
-  m_end_frame = -1;
-  m_global_beam = 1e10;
-  m_word_end_beam = 1e10;
-  m_eq_depth_beam = 1e10;
-  m_eq_wc_beam = 1e10;
-  m_fan_in_beam = 1e10;
-  m_fan_out_beam = 1e10;
-  m_state_beam = 1e10;
-  m_print_text_result = 0;
-  m_print_state_segmentation = false;
-  m_keep_state_segmentation = false;
-  m_similar_lm_hist_span = 0;
-  m_lm_scale = 1;
-  m_max_num_tokens = 0;
   m_active_token_list = new std::vector<TPLexPrefixTree::Token*>;
   m_new_token_list = new std::vector<TPLexPrefixTree::Token*>;
   m_word_end_token_list = new std::vector<TPLexPrefixTree::Token*>;
-  m_ngram = NULL;
-  m_fsa_lm = NULL;
-  m_lookahead_ngram = NULL;
-  m_word_boundary_id = 0;
-  m_duration_scale = 0;
-  m_transition_scale = 1;
-  m_lm_lookahead = 0;
-  m_max_lookahead_score_list_size = DEFAULT_MAX_LOOKAHEAD_SCORE_LIST_SIZE;
-  m_max_node_lookahead_buffer_size = DEFAULT_MAX_NODE_LOOKAHEAD_BUFFER_SIZE;
-  m_insertion_penalty = 0;
-  filecount = 0;
-  m_lm_lookahead_initialized = false;
-  m_use_sentence_boundary = false;
-  m_sentence_start_id = -1;
-  m_sentence_end_id = -1;
-  m_generate_word_graph = false;
-  m_use_word_pair_approximation = true;
-  m_use_lm_cache = true;
-  m_best_final_token = NULL;
-  m_require_sentence_end = false;
-  m_remove_pronunciation_id = false;
 #ifdef ENABLE_MULTIWORD_SUPPORT
   m_split_multiwords = false;
 #endif
+}
+
+TokenPassSearch::~TokenPassSearch() {
+  delete m_active_token_list;
+  delete m_new_token_list;
+  delete m_word_end_token_list;
+  for (std::vector<LMHistory *>::iterator it=m_lmhist_dealloc_table.begin();
+       it!=m_lmhist_dealloc_table.end();++it) {
+    delete[] *it;
+  }
+  for (std::vector<TPLexPrefixTree::Token *>::iterator it=m_token_dealloc_table.begin();
+       it!=m_token_dealloc_table.end();++it) {
+    delete[] *it;
+  }
 }
 
 void TokenPassSearch::set_word_boundary(const std::string &word)
@@ -163,7 +189,7 @@ void TokenPassSearch::reset_search(int start_frame)
   t->lm_log_prob = 0;
   t->cur_am_log_prob = 0;
   t->cur_lm_log_prob = 0;
-  t->lm_history = new LMHistory(m_null_word, NULL);
+  t->lm_history = acquire_lmhist(&m_null_word, NULL);
   hist::link(t->lm_history);
 
   if (m_generate_word_graph) {
@@ -188,9 +214,9 @@ void TokenPassSearch::reset_search(int start_frame)
     t->fsa_lm_node = m_fsa_lm->initial_node_id();
 
   if (m_use_sentence_boundary) {
-    LMHistory * sentence_start = new LMHistory(
-      m_word_repository[m_sentence_start_id], t->lm_history);
-    hist::unlink(t->lm_history);
+    LMHistory * sentence_start = acquire_lmhist(
+      &m_word_repository[m_sentence_start_id], t->lm_history);
+    hist::unlink(t->lm_history, &m_lmh_pool);
     t->lm_history = sentence_start;
     hist::link(t->lm_history);
   }
@@ -763,12 +789,12 @@ void TokenPassSearch::propagate_token(TPLexPrefixTree::Token *token)
       // Add sentence_end and sentence_start and propagate the token with new word history
       LMHistory * temp_lm_history = token->lm_history;
 
-      token->lm_history = new LMHistory(
-        m_word_repository[m_sentence_end_id], token->lm_history);
+      token->lm_history = acquire_lmhist(
+        &m_word_repository[m_sentence_end_id], token->lm_history);
       hist::link(token->lm_history);
       token->lm_history->word_start_frame = m_frame;
-      token->lm_history = new LMHistory(
-        m_word_repository[m_sentence_start_id], token->lm_history);
+      token->lm_history = acquire_lmhist(
+        &m_word_repository[m_sentence_start_id], token->lm_history);
       hist::link(token->lm_history);
       token->lm_history->word_start_frame = m_frame;
       token->lm_hist_code = compute_lm_hist_hash_code(token->lm_history);
@@ -780,8 +806,8 @@ void TokenPassSearch::propagate_token(TPLexPrefixTree::Token *token)
                              source_node->arcs[i].log_prob);
       }
 
-      hist::unlink(token->lm_history->previous);
-      hist::unlink(token->lm_history);
+      hist::unlink(token->lm_history->previous, &m_lmh_pool);
+      hist::unlink(token->lm_history, &m_lmh_pool);
       token->lm_history = temp_lm_history;
     }
   }
@@ -814,7 +840,7 @@ void TokenPassSearch::propagate_token(TPLexPrefixTree::Token *token)
                              source_node->arcs[i].log_prob);
       }
 
-      hist::unlink(token->lm_history);
+      hist::unlink(token->lm_history, &m_lmh_pool);
       token->lm_history = temp_lm_history;
     }
   }
@@ -823,7 +849,7 @@ void TokenPassSearch::propagate_token(TPLexPrefixTree::Token *token)
 void TokenPassSearch::append_to_word_history(TPLexPrefixTree::Token & token,
                                              const LMHistory::Word & word)
 {
-  token.lm_history = new LMHistory(word, token.lm_history);
+  token.lm_history = acquire_lmhist(&word, token.lm_history);
   hist::link(token.lm_history);
   token.lm_history->word_start_frame = m_frame;
   update_lm_log_prob(token);
@@ -923,12 +949,12 @@ TokenPassSearch::move_token_to_node(TPLexPrefixTree::Token *token,
 
         // Add the word to lm_history.
         assert(updated_token.word_start_frame >= 0);
-        updated_token.lm_history = new LMHistory(word,
+        updated_token.lm_history = acquire_lmhist(&word,
                                                  token->lm_history);
         updated_token.lm_history->word_start_frame =
           updated_token.word_start_frame;
         updated_token.word_start_frame = -1;
-        auto_lm_history.adopt(updated_token.lm_history);
+        auto_lm_history.adopt(updated_token.lm_history, &m_lmh_pool);
 
         update_lm_log_prob(updated_token);
 
@@ -945,17 +971,17 @@ TokenPassSearch::move_token_to_node(TPLexPrefixTree::Token *token,
 
           // Add sentence start and word boundary to the LM history
           // after sentence_end_id
-          updated_token.lm_history = new LMHistory(
-            m_word_repository[m_sentence_start_id],
+          updated_token.lm_history = acquire_lmhist(
+            &m_word_repository[m_sentence_start_id],
             updated_token.lm_history);
           updated_token.lm_history->word_start_frame = m_frame;
           if (m_word_boundary_id > 0) {
-            updated_token.lm_history = new LMHistory(
-              m_word_repository[m_word_boundary_id],
+            updated_token.lm_history = acquire_lmhist(
+              &m_word_repository[m_word_boundary_id],
               updated_token.lm_history);
             updated_token.lm_history->word_start_frame = m_frame;
           }
-          auto_lm_history.adopt(updated_token.lm_history);
+          auto_lm_history.adopt(updated_token.lm_history, &m_lmh_pool);
 
           if (m_fsa_lm) {
             updated_token.fsa_lm_node = m_fsa_lm->initial_node_id();
@@ -1224,7 +1250,7 @@ TokenPassSearch::move_token_to_node(TPLexPrefixTree::Token *token,
             > similar_lm_hist->total_log_prob) {
           // Replace the previous token
           new_token = similar_lm_hist;
-          hist::unlink(new_token->lm_history);
+          hist::unlink(new_token->lm_history, &m_lmh_pool);
           hist::unlink(new_token->word_history);
           hist::unlink(new_token->state_history);
 
@@ -2199,18 +2225,34 @@ float TokenPassSearch::get_lm_trigram_lookahead(int w1, int w2,
 TPLexPrefixTree::Token*
 TokenPassSearch::acquire_token(void)
 {
-  TPLexPrefixTree::Token *t;
   if (m_token_pool.size() == 0) {
     TPLexPrefixTree::Token *tt =
       new TPLexPrefixTree::Token[TOKEN_RESERVE_BLOCK];
+    m_token_dealloc_table.push_back(tt);
     for (int i = 0; i < TOKEN_RESERVE_BLOCK; i++)
       m_token_pool.push_back(&tt[i]);
   }
-  t = m_token_pool.back();
+  TPLexPrefixTree::Token *t = m_token_pool.back();
   m_token_pool.pop_back();
   t->recent_word_graph_node = -1;
   t->word_history = NULL;
   return t;
+}
+
+LMHistory *
+TokenPassSearch::acquire_lmhist(const LMHistory::Word * last_word, LMHistory * previous) {
+  if (m_lmh_pool.size() == 0) {
+    LMHistory * lmh_block = new LMHistory[TOKEN_RESERVE_BLOCK];
+    m_lmhist_dealloc_table.push_back(lmh_block);
+    for (int i = 0; i < TOKEN_RESERVE_BLOCK; i++)
+      m_lmh_pool.push_back(&lmh_block[i]);
+  }
+  LMHistory *lmh = m_lmh_pool.back();
+  m_lmh_pool.pop_back();
+  lmh->last_word = last_word;
+  lmh->previous = previous;
+  if (previous) hist::link(lmh->previous);
+  return lmh;
 }
 
 void TokenPassSearch::release_token(TPLexPrefixTree::Token *token)
@@ -2218,12 +2260,23 @@ void TokenPassSearch::release_token(TPLexPrefixTree::Token *token)
   if (token->recent_word_graph_node >= 0)
     word_graph.unlink(token->recent_word_graph_node);
   token->recent_word_graph_node = -1;
-  hist::unlink(token->lm_history);
+  hist::unlink(token->lm_history, &m_lmh_pool);
   hist::unlink(token->word_history);
   hist::unlink(token->state_history);
   //TPLexPrefixTree::PathHistory::unlink(token->token_path);
   m_token_pool.push_back(token);
 }
+
+void TokenPassSearch::release_lmhist(LMHistory *lmhist) {
+  lmhist->last_word=NULL;
+  lmhist->previous=NULL;
+  lmhist->reference_count = 0;
+  lmhist->printed = false;
+  lmhist->word_start_frame = 0;
+  lmhist->word_first_silence_frame=-1;
+  m_lmh_pool.push_back(lmhist);
+}
+
 
 void TokenPassSearch::save_token_statistics(int count)
 {
@@ -2327,7 +2380,7 @@ void TokenPassSearch::update_final_tokens()
     }
 
     // Add sentence end in LMHistory.
-    token->lm_history = new LMHistory(m_word_repository[m_sentence_end_id],
+    token->lm_history = acquire_lmhist(&m_word_repository[m_sentence_end_id],
                                       token->lm_history);
     hist::link(token->lm_history);
     token->lm_history->word_start_frame = m_frame;

--- a/decoder/src/TokenPassSearch.hh
+++ b/decoder/src/TokenPassSearch.hh
@@ -62,6 +62,7 @@ public:
 
   TokenPassSearch(TPLexPrefixTree &lex, Vocabulary &vocab,
                   Acoustics *acoustics);
+  ~TokenPassSearch();
 
   /// \brief Resets the search and creates the initial token.
   ///
@@ -554,10 +555,17 @@ private:
   }
 
   TPLexPrefixTree::Token* acquire_token(void);
+  LMHistory* acquire_lmhist(const LMHistory::Word *, LMHistory *);
   void release_token(TPLexPrefixTree::Token *token);
+  void release_lmhist(LMHistory *);
 
   void save_token_statistics(int count);
   //void print_token_path(TPLexPrefixTree::PathHistory *hist);
+
+  // Help variables to cope with memory leaks
+  // Vector of pointers to memory blocks for m_token_pool, this is only for freeing up memory at the destructor
+  std::vector<TPLexPrefixTree::Token *> m_token_dealloc_table;
+  std::vector<LMHistory *> m_lmhist_dealloc_table;
 
 public:
 
@@ -577,6 +585,7 @@ private:
   token_list_type * m_new_token_list;
   token_list_type * m_word_end_token_list;
   token_list_type m_token_pool;
+  std::vector<LMHistory*> m_lmh_pool;
 
   std::vector<TPLexPrefixTree::Node*> m_active_node_list;
 

--- a/decoder/src/Toolbox.cc
+++ b/decoder/src/Toolbox.cc
@@ -16,26 +16,27 @@ using namespace std;
 Toolbox::Toolbox()
   : m_use_stack_decoder(0),
 
-    m_hmm_reader(),
-    m_hmm_map(m_hmm_reader.hmm_map()),
-    m_hmms(m_hmm_reader.hmms()),
+    m_hmm_reader(NULL),
+    m_hmm_map(NULL),
+    m_hmms(NULL),
 
-    m_lexicon_reader(m_hmm_map, m_hmms),
-    m_lexicon(m_lexicon_reader.lexicon()),
-    m_vocabulary(m_lexicon_reader.vocabulary()),
-    m_tp_lexicon(m_hmm_map, m_hmms),
-    m_tp_lexicon_reader(m_hmm_map, m_hmms, m_tp_lexicon, m_tp_vocabulary),
+    m_lexicon_reader(NULL),
+    m_lexicon(NULL),
+    m_vocabulary(NULL),
+    m_tp_lexicon(NULL),
+    m_tp_lexicon_reader(NULL),
     m_lexicon_read(false),
-    m_tp_search(m_tp_lexicon, m_tp_vocabulary, &m_lna_reader),
+    m_tp_vocabulary(NULL),
+    m_tp_search(NULL),
 
     m_acoustics(NULL),
-    m_lna_reader(),
+    m_lna_reader(NULL),
     m_one_frame_acoustics(),
     m_fsa_lm(NULL),
     m_lookahead_ngram(NULL),
 
-    m_expander(m_hmms, m_lexicon, m_lna_reader),
-    m_search(m_expander, m_vocabulary),
+    m_expander(NULL),
+    m_search(NULL),
     m_last_guaranteed_history(NULL)
 {
 }
@@ -53,13 +54,37 @@ Toolbox::~Toolbox()
   if (m_fsa_lm) {
     delete m_fsa_lm;
   }
+
+  if (m_tp_vocabulary) {
+    delete m_tp_vocabulary;
+  }
+
+  if (m_lna_reader) {
+    delete m_lna_reader;
+  }
+
+  if (m_tp_lexicon) {
+    delete m_tp_lexicon;
+  }
+
+  if (m_tp_lexicon_reader) {
+    delete m_tp_lexicon_reader;
+  }
+
+  if (m_tp_search) {
+    delete m_tp_search;
+  }
+
+  if (m_hmm_reader) {
+    delete m_hmm_reader;
+  }
 }
 
 void
 Toolbox::expand(int frame, int frames)
 { 
-  m_expander.expand(frame, frames);
-  m_expander.sort_words();
+  m_expander->expand(frame, frames);
+  m_expander->sort_words();
 }
 
 const std::string&
@@ -67,8 +92,8 @@ Toolbox::best_word()
 {
   static const std::string noword("*");
 
-  if (m_expander.words().size() > 0)
-    return m_vocabulary.word(m_expander.words()[0]->word_id);
+  if (m_expander->words().size() > 0)
+    return m_vocabulary->word(m_expander->words()[0]->word_id);
   else
     return noword;
 }
@@ -76,14 +101,14 @@ Toolbox::best_word()
 void
 Toolbox::print_words(int words)
 {
-  m_expander.sort_words(words);
-  const std::vector<Expander::Word*> &sorted_words = m_expander.words();
+  m_expander->sort_words(words);
+  const std::vector<Expander::Word*> &sorted_words = m_expander->words();
 
   if (words == 0 || words > sorted_words.size())
     words = sorted_words.size();
 
   for (int i = 0; i < words; i++) {
-    std::cout << m_vocabulary.word(sorted_words[i]->word_id) << " "
+    std::cout << m_vocabulary->word(sorted_words[i]->word_id) << " "
               << sorted_words[i]->best_length << " "
               << sorted_words[i]->best_log_prob() << " "
               << sorted_words[i]->best_avg_log_prob << " "
@@ -94,9 +119,9 @@ Toolbox::print_words(int words)
 int
 Toolbox::find_word(const std::string &word)
 {
-  const std::vector<Expander::Word*> &sorted_words = m_expander.words();
+  const std::vector<Expander::Word*> &sorted_words = m_expander->words();
   for (int i = 0; i < sorted_words.size(); i++) {
-    if (m_vocabulary.word(sorted_words[i]->word_id) == word)
+    if (m_vocabulary->word(sorted_words[i]->word_id) == word)
       return i + 1;
   }
   return -1;
@@ -108,7 +133,13 @@ Toolbox::hmm_read(const char *file)
   std::ifstream in(file);
   if (!in)
     throw OpenError();
-  m_hmm_reader.read(in);
+  if (m_hmm_reader) {
+    delete m_hmm_reader;
+  }
+  m_hmm_reader = new NowayHmmReader();
+  m_hmm_map = &(m_hmm_reader->hmm_map());
+  m_hmms = &(m_hmm_reader->hmms());
+  m_hmm_reader->read(in);
 }
 
 void Toolbox::duration_read(const char *dur_file)
@@ -116,25 +147,83 @@ void Toolbox::duration_read(const char *dur_file)
   std::ifstream dur_in(dur_file);
   if (!dur_in)
     throw OpenError();
-  m_hmm_reader.read_durations(dur_in);
-  m_expander.set_post_durations(true);
+  m_hmm_reader->read_durations(dur_in);
 }
+
+void
+Toolbox::reinitialize_search() {
+  m_last_guaranteed_history = NULL;
+  m_lexicon_read = false;
+
+  if (m_tp_vocabulary) {
+    delete m_tp_vocabulary;
+  }
+
+  m_tp_vocabulary = new Vocabulary();
+  if (m_lna_reader) {
+    delete m_lna_reader;
+  }
+  m_lna_reader = new LnaReaderCircular;
+
+
+  if (m_tp_lexicon) {
+    delete m_tp_lexicon;
+  }
+  m_tp_lexicon = new TPLexPrefixTree(*m_hmm_map, *m_hmms);
+
+  if (m_tp_lexicon_reader) {
+    delete m_tp_lexicon_reader;
+  }
+  m_tp_lexicon_reader = new TPNowayLexReader(*m_hmm_map, *m_hmms, *m_tp_lexicon, *m_tp_vocabulary);
+
+  if (m_tp_search) {
+    delete m_tp_search;
+  }
+  m_tp_search = new TokenPassSearch(*m_tp_lexicon, *m_tp_vocabulary, m_lna_reader);
+
+  if (m_use_stack_decoder) {
+  if (m_expander) {
+    delete m_expander;
+  }
+  m_expander = new Expander(*m_hmms, *m_lna_reader);
+  m_expander->set_post_durations(true);
+  m_expander->set_lexicon(m_lexicon);
+
+  if (m_lexicon_reader) {
+    delete m_lexicon_reader;
+  }
+  m_lexicon_reader = new NowayLexiconReader(*m_hmm_map, *m_hmms);
+
+  m_lexicon = &(m_lexicon_reader->lexicon());
+  m_vocabulary = &(m_lexicon_reader->vocabulary());
+
+  if (m_search) {
+    delete m_search;
+  }
+  m_search = new Search(*m_expander, *m_vocabulary);
+  }
+}
+
 
 void
 Toolbox::lex_read(const char *filename)
 {
+  if (!m_tp_search) {
+    reinitialize_search();
+  }
+
   FILE *file = fopen(filename, "r");
   if (!file)
     throw OpenError();
   if (m_use_stack_decoder)
   {
-    m_lexicon_reader.read(file);
+    m_lexicon_reader->read(file);
   }
   else
   {
-    m_tp_lexicon_reader.read(file, m_word_boundary);
+    m_tp_lexicon_reader->read(file, m_word_boundary);
     if (!m_word_boundary.empty()) {
-      m_tp_search.set_word_boundary(m_word_boundary);
+      m_tp_search->set_word_boundary(m_word_boundary);
     }
   }
   fclose(file);
@@ -144,17 +233,17 @@ Toolbox::lex_read(const char *filename)
 const std::string & Toolbox::lex_word() const
 {
   if (m_use_stack_decoder)
-    return m_lexicon_reader.word();
+    return m_lexicon_reader->word();
   else
-    return m_tp_lexicon_reader.word();
+    return m_tp_lexicon_reader->word();
 }
 
 const std::string & Toolbox::lex_phone() const
 {
   if (m_use_stack_decoder)
-    return m_lexicon_reader.phone();
+    return m_lexicon_reader->phone();
   else
-    return m_tp_lexicon_reader.phone();
+    return m_tp_lexicon_reader->phone();
 }
 
 
@@ -164,8 +253,9 @@ Toolbox::interpolated_ngram_read(const std::vector<std::string> lmnames,
 
   // Loading binary models doesn't work yet !
   InterTreeGram *itg = new InterTreeGram(lmnames, weights);
-  if (m_use_stack_decoder) m_search.add_ngram(itg, 1.0);
-  else m_tp_search.set_ngram(itg);
+  if (m_use_stack_decoder) m_search->add_ngram(itg, 1.0);
+  else m_tp_search->set_ngram(itg);
+  m_ngrams.push_back(itg);
 }
 
 
@@ -179,8 +269,13 @@ Toolbox::ngram_read(const char *file, const bool binary, bool quiet)
   }
 
   if (!m_use_stack_decoder && m_ngrams.size() > 0) {
-    fprintf(stderr, "Trying to load more than one ngram. You need to use interploated_ngram_read() instead of ngram_read(). Exit.\n");
-    exit(-1);
+    if (m_ngrams.size() > 1) {
+      fprintf(stderr, "Trying to load more than one ngram (%lu). You need to use interploated_ngram_read() instead of ngram_read(). Exit.\n", m_ngrams.size());
+      exit(-1);
+    }
+    fprintf(stderr, "Replacing the current n-gram model\n");
+    delete m_ngrams[0];
+    m_ngrams.clear();
   }
 
   m_ngrams.push_back(new TreeGram());
@@ -191,10 +286,10 @@ Toolbox::ngram_read(const char *file, const bool binary, bool quiet)
     // LM weights removed from interface, but it is only
     // supported in the old stack decoder. Hence hard-wired
     // LM weight 1.0
-    num_oolm = m_search.add_ngram(m_ngrams.back(), 1.0);
+    num_oolm = m_search->add_ngram(m_ngrams.back(), 1.0);
   }
   else {
-    num_oolm = m_tp_search.set_ngram(m_ngrams.back());
+    num_oolm = m_tp_search->set_ngram(m_ngrams.back());
   }
 
   if ((num_oolm > 0) && !quiet) {
@@ -227,10 +322,10 @@ Toolbox::htk_lattice_grammar_read(const char *file, bool quiet)
 
   int num_oolm = 0;
   if (m_use_stack_decoder) {
-    num_oolm = m_search.add_ngram(m_ngrams.back(), 1.0);
+    num_oolm = m_search->add_ngram(m_ngrams.back(), 1.0);
   }
   else {
-    num_oolm = m_tp_search.set_ngram(m_ngrams.back());
+    num_oolm = m_tp_search->set_ngram(m_ngrams.back());
   }
 
   if ((num_oolm > 0) && !quiet) {
@@ -254,7 +349,7 @@ Toolbox::fsa_lm_read(const char *file, bool bin, bool quiet)
     m_fsa_lm->trim();
   }
 
-  int num_oolm = m_tp_search.set_fsa_lm(m_fsa_lm);
+  int num_oolm = m_tp_search->set_fsa_lm(m_fsa_lm);
 
   if ((num_oolm > 0) && !quiet) {
     cerr << num_oolm << " words in the vocabulary were not found in the FSA LM." << endl;
@@ -269,7 +364,7 @@ Toolbox::read_lookahead_ngram(const char *file, const bool binary, bool quiet)
   if (strlen(file) == 0)
   {
     if (m_ngrams.size() > 0)
-      num_oolm = m_tp_search.set_lookahead_ngram(m_ngrams.back());
+      num_oolm = m_tp_search->set_lookahead_ngram(m_ngrams.back());
   }
   else
   {
@@ -277,10 +372,13 @@ Toolbox::read_lookahead_ngram(const char *file, const bool binary, bool quiet)
     if (!in.file) {
         throw OpenError();
     }
+    if (m_lookahead_ngram) {
+      delete m_lookahead_ngram;
+    }
     m_lookahead_ngram = new TreeGram();
     m_lookahead_ngram->read(in.file, binary);
     assert(m_lookahead_ngram->get_type()==TreeGram::BACKOFF);
-    num_oolm = m_tp_search.set_lookahead_ngram(m_lookahead_ngram);
+    num_oolm = m_tp_search->set_lookahead_ngram(m_lookahead_ngram);
   }
 
   if ((num_oolm > 0) && !quiet) {
@@ -289,9 +387,12 @@ Toolbox::read_lookahead_ngram(const char *file, const bool binary, bool quiet)
 }
 
 void Toolbox::interpolated_lookahead_ngram_read(const std::vector<std::string> lmnames, const std::vector<float> weights) {
+  if (m_lookahead_ngram) {
+    delete m_lookahead_ngram;
+  }
   //FIXME: Not checking that the type is BACKOFF
   m_lookahead_ngram = new InterTreeGram(lmnames, weights);
-  m_tp_search.set_lookahead_ngram(m_lookahead_ngram);;
+  m_tp_search->set_lookahead_ngram(m_lookahead_ngram);;
 }
 
 void
@@ -301,42 +402,42 @@ Toolbox::read_word_classes(const char *file)
 
 #ifdef ENABLE_WORDCLASS_SUPPORT
   ifstream ifs(file);
-  m_word_classes.read(ifs, m_tp_vocabulary);
-  m_tp_search.set_word_classes(&m_word_classes);
+  m_word_classes.read(ifs, *m_tp_vocabulary);
+  m_tp_search->set_word_classes(&m_word_classes);
 #endif
 }
 
 void
 Toolbox::lna_open(const char *file, int size)
 {
-  m_lna_reader.open_file(file, size);
-  m_acoustics = &m_lna_reader;
+  m_lna_reader->open_file(file, size);
+  m_acoustics = m_lna_reader;
 }
 
 void
 Toolbox::lna_open_fd(const int fd, int size)
 {
-  m_lna_reader.open_fd(fd, size);
-  m_acoustics = &m_lna_reader;
+  m_lna_reader->open_fd(fd, size);
+  m_acoustics = m_lna_reader;
 }
 
 void
 Toolbox::lna_close()
 {
-  m_lna_reader.close();
+  m_lna_reader->close();
 }
 
 void
 Toolbox::print_hypo(Hypo &hypo)
 {
-  m_search.print_hypo(hypo);
+  m_search->print_hypo(hypo);
 }
 
 bool
 Toolbox::runto(int frame)
 {
-  while (frame > m_search.frame()) {
-    bool ok = m_search.run();
+  while (frame > m_search->frame()) {
+    bool ok = m_search->run();
     if (!ok)
       return false;
   }
@@ -347,7 +448,7 @@ Toolbox::runto(int frame)
 bool
 Toolbox::recognize_segment(int start_frame, int end_frame)
 {
-  return m_search.recognize_segment(start_frame, end_frame);
+  return m_search->recognize_segment(start_frame, end_frame);
 }
 
 void
@@ -376,12 +477,12 @@ Toolbox::segment(const std::string &str, int start_frame, int end_frame)
 void
 Toolbox::init(int expand_window)
 {
-  if (m_lna_reader.num_models() != m_hmm_reader.num_models()) {
-    cerr << "WARNING: " << m_lna_reader.num_models() << " states in LNA, but "
-    		<< m_hmm_reader.num_models() << " states in HMMs" << endl;
+  if (m_lna_reader->num_models() != m_hmm_reader->num_models()) {
+    cerr << "WARNING: " << m_lna_reader->num_models() << " states in LNA, but "
+    		<< m_hmm_reader->num_models() << " states in HMMs" << endl;
   }
 
-  m_search.init_search(expand_window);
+  m_search->init_search(expand_window);
 }
 
 const bytestype& Toolbox::best_hypo_string(bool print_all, bool output_time) {
@@ -389,7 +490,7 @@ const bytestype& Toolbox::best_hypo_string(bool print_all, bool output_time) {
   static std::string retval;
   retval.clear();
 
-  m_tp_search.get_path(hist_vec, print_all, print_all ? NULL : m_last_guaranteed_history);
+  m_tp_search->get_path(hist_vec, print_all, print_all ? NULL : m_last_guaranteed_history);
   bool all_guaranteed = true;
 
   for (int i = hist_vec.size() - 1; i >= 0; i--) {
@@ -419,22 +520,24 @@ const bytestype& Toolbox::best_hypo_string(bool print_all, bool output_time) {
 
 void Toolbox::set_lm_scale(float lm_scale)
 {
-  m_search.set_lm_scale(lm_scale);
-  m_tp_search.set_lm_scale(lm_scale);
-  m_tp_lexicon.set_lm_scale(lm_scale);
+  if (m_use_stack_decoder) {
+    m_search->set_lm_scale(lm_scale);
+  } else {
+    m_tp_search->set_lm_scale(lm_scale);
+    m_tp_lexicon->set_lm_scale(lm_scale);
+  }
 }
 
 void Toolbox::set_word_boundary(const std::string & word)
 {
   if (m_use_stack_decoder) {
-    m_search.set_word_boundary(word);
+    m_search->set_word_boundary(word);
   }
   else {
     // set_word_boundary() has no effect after the language model has been read.
     // Calling them in wrong order will result in confusing errors later.
     if ((m_ngrams.size() > 0) || m_lexicon_read) {
-      cerr << "set_word_boundary() has to be called before reading language model or lexicon." << endl;
-      exit(-1);
+      cerr << "Warning, set_word_boundary() has to be called before reading language model or lexicon." << endl;
     }
     m_word_boundary = word;
   }

--- a/decoder/src/Toolbox.hh
+++ b/decoder/src/Toolbox.hh
@@ -39,7 +39,7 @@ public:
   ///
   void duration_read(const char *dur_file);
 
-  const std::vector<Hmm> &hmms() const { return m_hmms; }
+  const std::vector<Hmm> &hmms() const { return *m_hmms; }
 
   // Lexicon
 
@@ -56,8 +56,8 @@ public:
   const std::string &word(int index) const 
   {
     if (m_use_stack_decoder)
-      return m_vocabulary.word(index); 
-    return m_tp_vocabulary.word(index);
+      return m_vocabulary->word(index); 
+    return m_tp_vocabulary->word(index);
   }
 
   // Ngram
@@ -118,12 +118,12 @@ public:
   void lna_open(const char *file, int size);
   void lna_open_fd(const int fd, int size);
   void lna_close();
-  void lna_seek(int frame) { m_lna_reader.seek(frame); }
+  void lna_seek(int frame) { m_lna_reader->seek(frame); }
   Acoustics &acoustics() { return *m_acoustics; }
   void use_one_frame_acoustics() 
   { 
     m_acoustics = &m_one_frame_acoustics; 
-    m_tp_search.set_acoustics(m_acoustics);
+    m_tp_search->set_acoustics(m_acoustics);
   }
   void set_one_frame(int frame, const std::vector<float> log_probs)
   {
@@ -136,34 +136,34 @@ public:
   const std::string &best_word();
   void print_words(int words);
   int find_word(const std::string &word);
-  std::vector<Expander::Word*> words() { return m_expander.words(); }
+  std::vector<Expander::Word*> words() { return m_expander->words(); }
 
   // Stack search
   void init(int expand_window);
-  bool expand_stack(int frame) { return m_search.expand_stack(frame); }
+  bool expand_stack(int frame) { return m_search->expand_stack(frame); }
   void expand_words(int frame, const std::string &words) 
-  { m_search.expand_words(frame, words); }
-  void go(int frame) { m_search.go(frame); }
+  { m_search->expand_words(frame, words); }
+  void go(int frame) { m_search->go(frame); }
   bool runto(int frame);
   bool recognize_segment(int start_frame, int end_frame);
 
   // Both searches
-  void reset(int frame) { if (m_use_stack_decoder) m_search.reset_search(frame);  else m_tp_search.reset_search(frame); m_last_guaranteed_history=NULL;}
-  void set_end(int frame) { if (m_use_stack_decoder) m_search.set_end_frame(frame); else m_tp_search.set_end_frame(frame); }
+  void reset(int frame) { if (m_use_stack_decoder) m_search->reset_search(frame);  else m_tp_search->reset_search(frame); m_last_guaranteed_history=NULL;}
+  void set_end(int frame) { if (m_use_stack_decoder) m_search->set_end_frame(frame); else m_tp_search->set_end_frame(frame); }
 
   /// \brief Proceeds decoding one frame.
   ///
   /// \return true if a frame was available, false if there are no more frames.
   ///
-  bool run() { return (m_use_stack_decoder?m_search.run():m_tp_search.run()); }
+  bool run() { return (m_use_stack_decoder?m_search->run():m_tp_search->run()); }
 
   // Token pass search
-  WordGraph &tp_word_graph() { return m_tp_search.word_graph; } 
+  WordGraph &tp_word_graph() { return m_tp_search->word_graph; } 
   void write_word_graph(const std::string &file_name)
-  { m_tp_search.write_word_graph(file_name); }
+  { m_tp_search->write_word_graph(file_name); }
   void print_best_lm_history(FILE *out=stdout) 
   { 
-    m_tp_search.print_lm_history(out, true); 
+    m_tp_search->print_lm_history(out, true); 
   }
   void print_best_lm_history_to_file(FILE *out) {print_best_lm_history(out);}
 
@@ -171,19 +171,19 @@ public:
   void segment(const std::string &str, int start_frame, int end_frame);
 
   // Info
-  TokenPassSearch &tp_search() { return m_tp_search; }
-  int frame() { return (m_use_stack_decoder?m_search.frame():m_tp_search.frame()); }
-  int first_frame() { return m_search.first_frame(); }
-  int last_frame() { return m_search.last_frame(); }
-  HypoStack &stack(int frame) { return m_search.stack(frame); }
+  TokenPassSearch &tp_search() { return *m_tp_search; }
+  int frame() { return (m_use_stack_decoder?m_search->frame():m_tp_search->frame()); }
+  int first_frame() { return m_search->first_frame(); }
+  int last_frame() { return m_search->last_frame(); }
+  HypoStack &stack(int frame) { return m_search->stack(frame); }
   void prune(int frame, int top);
   int paths() const { return HypoPath::g_count; }
 
   const bytestype &best_hypo_string(bool print_all, bool output_time);
 
   // Options
-  void set_forced_end(bool forced_end) { m_expander.set_forced_end(forced_end); }
-  void set_hypo_limit(int hypo_limit) { m_search.set_hypo_limit(hypo_limit); } 
+  void set_forced_end(bool forced_end) { m_expander->set_forced_end(forced_end); }
+  void set_hypo_limit(int hypo_limit) { m_search->set_hypo_limit(hypo_limit); } 
 
   /// \brief Sets how many words in the word histories of two hypotheses have to
   /// match for the hypotheses to be considered similar (and only the better to
@@ -191,10 +191,10 @@ public:
   ///
   /// This should usually equal to the n-gram model order.
   ///
-  void set_prune_similar(int prune_similar) { m_search.set_prune_similar(prune_similar); m_tp_search.set_similar_lm_history_span(prune_similar); }
+  void set_prune_similar(int prune_similar) { m_use_stack_decoder?m_search->set_prune_similar(prune_similar):m_tp_search->set_similar_lm_history_span(prune_similar); }
 
-  void set_word_limit(int word_limit) { m_search.set_word_limit(word_limit); }
-  void set_word_beam(float word_beam) { m_search.set_word_beam(word_beam); }
+  void set_word_limit(int word_limit) { m_search->set_word_limit(word_limit); }
+  void set_word_beam(float word_beam) { m_search->set_word_beam(word_beam); }
 
   /// \brief Sets a scaling factor for the language model log probabilities.
   ///
@@ -203,24 +203,24 @@ public:
   ///
   void set_lm_scale(float lm_scale);
 
-  void set_lm_offset(float lm_offset) { m_search.set_lm_offset(lm_offset); }
-  void set_unk_offset(float unk_offset) { m_search.set_unk_offset(unk_offset); }
-  void set_token_limit(int limit) { m_expander.set_token_limit(limit); m_tp_search.set_max_num_tokens(limit); }
-  void set_state_beam(float beam) { m_expander.set_beam(beam); }
-  void set_duration_scale(float scale) { m_expander.set_duration_scale(scale); m_tp_search.set_duration_scale(scale); }
-  void set_transition_scale(float scale) { m_expander.set_transition_scale(scale); m_tp_search.set_transition_scale(scale); }
-  void set_rabiner_post_mode(int mode) { m_expander.set_rabiner_post_mode(mode); }
-  void set_hypo_beam(float beam) { m_search.set_hypo_beam(beam); }
+  void set_lm_offset(float lm_offset) { m_search->set_lm_offset(lm_offset); }
+  void set_unk_offset(float unk_offset) { m_search->set_unk_offset(unk_offset); }
+  void set_token_limit(int limit) { m_use_stack_decoder?m_expander->set_token_limit(limit):m_tp_search->set_max_num_tokens(limit); }
+  void set_state_beam(float beam) { m_expander->set_beam(beam); }
+  void set_duration_scale(float scale) { m_use_stack_decoder?m_expander->set_duration_scale(scale):m_tp_search->set_duration_scale(scale); }
+  void set_transition_scale(float scale) { m_use_stack_decoder?m_expander->set_transition_scale(scale):m_tp_search->set_transition_scale(scale); }
+  void set_rabiner_post_mode(int mode) { m_expander->set_rabiner_post_mode(mode); }
+  void set_hypo_beam(float beam) { m_search->set_hypo_beam(beam); }
   void set_global_beam(float beam) 
-  { m_search.set_global_beam(beam); m_tp_search.set_global_beam(beam); }
-  void set_word_end_beam(float beam) { m_tp_search.set_word_end_beam(beam); }
-  void set_eq_depth_beam(float beam) { m_tp_search.set_eq_depth_beam(beam); }
-  void set_eq_word_count_beam(float beam) { m_tp_search.set_eq_word_count_beam(beam); }
-  void set_fan_in_beam(float beam) { m_tp_search.set_fan_in_beam(beam); }
-  void set_fan_out_beam(float beam) { m_tp_search.set_fan_out_beam(beam); }
-  void set_tp_state_beam(float beam) { m_tp_search.set_state_beam(beam); }
+  { m_use_stack_decoder?m_search->set_global_beam(beam):m_tp_search->set_global_beam(beam); }
+  void set_word_end_beam(float beam) { m_tp_search->set_word_end_beam(beam); }
+  void set_eq_depth_beam(float beam) { m_tp_search->set_eq_depth_beam(beam); }
+  void set_eq_word_count_beam(float beam) { m_tp_search->set_eq_word_count_beam(beam); }
+  void set_fan_in_beam(float beam) { m_tp_search->set_fan_in_beam(beam); }
+  void set_fan_out_beam(float beam) { m_tp_search->set_fan_out_beam(beam); }
+  void set_tp_state_beam(float beam) { m_tp_search->set_state_beam(beam); }
   void set_max_state_duration(int duration) 
-  { m_expander.set_max_state_duration(duration); }
+  { m_expander->set_max_state_duration(duration); }
 
   /// \brief Enables or disables multiword splitting in the decoder.
   ///
@@ -229,7 +229,7 @@ public:
   ///
   void set_split_multiwords(bool b) {
 #ifdef ENABLE_MULTIWORD_SUPPORT
-	  m_tp_search.set_split_multiwords(b);
+	  m_tp_search->set_split_multiwords(b);
 #endif
   }
 
@@ -239,28 +239,28 @@ public:
   ///
   /// \param lmlh 0=None, 1=Only in first subtree nodes, 2=Full.
   ///
-  void set_lm_lookahead(int lmlh) { m_tp_lexicon.set_lm_lookahead(lmlh); m_tp_search.set_lm_lookahead(lmlh); }
+  void set_lm_lookahead(int lmlh) { m_tp_lexicon->set_lm_lookahead(lmlh); m_tp_search->set_lm_lookahead(lmlh); }
 
-  void set_cross_word_triphones(bool cw_triphones) { m_tp_lexicon.set_cross_word_triphones(cw_triphones); }
-  void set_insertion_penalty(float ip) { m_tp_search.set_insertion_penalty(ip); }
-  void set_silence_is_word(bool b) { m_tp_lexicon.set_silence_is_word(b); m_tp_lexicon_reader.set_silence_is_word(b); }
-  void set_ignore_case(bool b) { m_tp_lexicon.set_ignore_case(b);}
-  void set_verbose(int verbose) { m_search.set_verbose(verbose); m_tp_lexicon.set_verbose(verbose); m_tp_search.set_verbose(verbose);}
-  void set_print_text_result(int print) { m_tp_search.set_print_text_result(print); }
-  void set_print_state_segmentation(int print) { m_tp_search.set_print_state_segmentation(print); }
-  void set_keep_state_segmentation(int value) { m_tp_search.set_keep_state_segmentation(value); }
+  void set_cross_word_triphones(bool cw_triphones) { m_tp_lexicon->set_cross_word_triphones(cw_triphones);
+ }
+  void set_insertion_penalty(float ip) { m_tp_search->set_insertion_penalty(ip); }
+  void set_silence_is_word(bool b) { m_tp_lexicon->set_silence_is_word(b); m_tp_lexicon_reader->set_silence_is_word(b); }
+  void set_ignore_case(bool b) { m_tp_lexicon->set_ignore_case(b);}
+  void set_verbose(int verbose) { if (m_use_stack_decoder) m_search->set_verbose(verbose); else {m_tp_lexicon->set_verbose(verbose); m_tp_search->set_verbose(verbose);}}
+  void set_print_text_result(int print) { m_tp_search->set_print_text_result(print); }
+  void set_print_state_segmentation(int print) { m_tp_search->set_print_state_segmentation(print); }
+  void set_keep_state_segmentation(int value) { m_tp_search->set_keep_state_segmentation(value); }
   void set_print_probs(bool print_probs) 
   { 
-    m_search.set_print_probs(print_probs); 
-    m_tp_search.set_print_probs(print_probs);
+    m_use_stack_decoder?m_search->set_print_probs(print_probs):m_tp_search->set_print_probs(print_probs);
   }
   void set_multiple_endings(int multiple_endings) 
-  { m_search.set_multiple_endings(multiple_endings); }
+  { m_search->set_multiple_endings(multiple_endings); }
   void set_print_indices(bool print_indices) 
-  { m_search.set_print_indices(print_indices); }
+  { m_search->set_print_indices(print_indices); }
   void set_print_frames(bool print_frames) 
   { 
-    m_search.set_print_frames(print_frames); 
+    m_search->set_print_frames(print_frames); 
   }
 
   /// \brief Sets the word that represents word boundary.
@@ -273,31 +273,31 @@ public:
   ///
   void set_word_boundary(const std::string &word);
 
-  void set_sentence_boundary(const std::string &start, const std::string &end) { m_tp_search.set_sentence_boundary(start, end); }
+  void set_sentence_boundary(const std::string &start, const std::string &end) { m_tp_search->set_sentence_boundary(start, end); }
 
-  void clear_hesitation_words() { m_tp_search.clear_hesitation_words(); }
+  void clear_hesitation_words() { m_tp_search->clear_hesitation_words(); }
 
-  void add_hesitation_word(const std::string & word) { m_tp_search.add_hesitation_word(word); }
+  void add_hesitation_word(const std::string & word) { m_tp_search->add_hesitation_word(word); }
 
-  void set_dummy_word_boundaries(bool value) { m_search.set_dummy_word_boundaries(value); }
-  void set_require_sentence_end(bool s) { m_tp_search.set_require_sentence_end(s); }
+  void set_dummy_word_boundaries(bool value) { m_search->set_dummy_word_boundaries(value); }
+  void set_require_sentence_end(bool s) { m_tp_search->set_require_sentence_end(s); }
 
-  void set_optional_short_silence(bool state) { m_tp_lexicon.set_optional_short_silence(state); }
+  void set_optional_short_silence(bool state) { m_tp_lexicon->set_optional_short_silence(state); }
 
-  void set_remove_pronunciation_id(bool remove) { m_tp_search.set_remove_pronunciation_id(remove); }
+  void set_remove_pronunciation_id(bool remove) { m_tp_search->set_remove_pronunciation_id(remove); }
 
-  void prune_lm_lookahead_buffers(int min_delta, int max_depth) { m_tp_lexicon.prune_lookahead_buffers(min_delta, max_depth); }
+  void prune_lm_lookahead_buffers(int min_delta, int max_depth) { m_tp_lexicon->prune_lookahead_buffers(min_delta, max_depth); }
 
   /// \brief If set to true, generates a word graph of the hypotheses during
   /// decoding (requires memory).
   ///
   void set_generate_word_graph(bool value)
-  { m_tp_search.set_generate_word_graph(value); }
+  { m_tp_search->set_generate_word_graph(value); }
 
   /// \brief Returns the value of the word graph generation flag.
   ///
   bool get_generate_word_graph() const
-  { return m_tp_search.get_generate_word_graph(); }
+  { return m_tp_search->get_generate_word_graph(); }
 
   /// \brief Enables or disables word pair approximation when building a word
   /// graph.
@@ -305,62 +305,64 @@ public:
   /// Enabled by default.
   ///
   void set_use_word_pair_approximation(bool b)
-  { m_tp_search.set_use_word_pair_approximation(b); }
+  { m_tp_search->set_use_word_pair_approximation(b); }
 
   void set_use_lm_cache(bool value)
-  { m_tp_search.set_use_lm_cache(value); }
+  { m_tp_search->set_use_lm_cache(value); }
 
   // Debug
   void print_prunings()
-  { m_search.print_prunings(); }
+  { m_search->print_prunings(); }
   void print_hypo(Hypo &hypo);
-  void print_sure() { m_search.print_sure(); }
+  void print_sure() { m_search->print_sure(); }
   void write_word_history(const std::string file_name) {
     io::Stream out(file_name, "w");
-    m_tp_search.write_word_history(out.file);
+    m_tp_search->write_word_history(out.file);
   }
-  void write_word_history() { m_tp_search.write_word_history(); }
-  void print_lm_history() { m_tp_search.print_lm_history(); }
+  void write_word_history() { m_tp_search->write_word_history(); }
+  void print_lm_history() { m_tp_search->print_lm_history(); }
   void write_state_segmentation(const std::string &file)
   { 
-    m_tp_search.print_state_history(io::Stream(file, "w").file);
+    m_tp_search->print_state_history(io::Stream(file, "w").file);
   }
 
-  TokenPassSearch &debug_get_tp() { return m_tp_search; }
-  TPLexPrefixTree &debug_get_tp_lex() { return m_tp_lexicon; }
+  TokenPassSearch &debug_get_tp() { return *m_tp_search; }
+  TPLexPrefixTree &debug_get_tp_lex() { return *m_tp_lexicon; }
   void debug_print_best_lm_history() 
-  { m_tp_search.debug_print_best_lm_history(); }
+  { m_tp_search->debug_print_best_lm_history(); }
 
   struct OpenError : public std::exception {
     virtual const char *what() const throw()
     { return "Toolbox: open error"; }
   };
 
-  void print_tp_lex_node(int node) { m_tp_lexicon.print_node_info(node, m_tp_vocabulary); }
-  void print_tp_lex_lookahead(int node) {m_tp_lexicon.print_lookahead_info(node, m_tp_vocabulary); }
+  void print_tp_lex_node(int node) { m_tp_lexicon->print_node_info(node, *m_tp_vocabulary); }
+  void print_tp_lex_lookahead(int node) {m_tp_lexicon->print_lookahead_info(node, *m_tp_vocabulary); }
+
+  void reinitialize_search();
 
 private:
   int m_use_stack_decoder;
   
-  NowayHmmReader m_hmm_reader;
-  std::map<std::string,int> &m_hmm_map;
-  std::vector<Hmm> &m_hmms;
+  NowayHmmReader *m_hmm_reader;
+  std::map<std::string,int> *m_hmm_map;
+  std::vector<Hmm> *m_hmms;
 
-  NowayLexiconReader m_lexicon_reader;
-  Lexicon &m_lexicon;
-  const Vocabulary &m_vocabulary;
+  NowayLexiconReader *m_lexicon_reader;
+  Lexicon *m_lexicon;
+  Vocabulary const *m_vocabulary;
 #ifdef ENABLE_WORDCLASS_SUPPORT
   WordClasses m_word_classes;
 #endif
 
-  TPLexPrefixTree m_tp_lexicon;
-  TPNowayLexReader m_tp_lexicon_reader;
+  TPLexPrefixTree *m_tp_lexicon;
+  TPNowayLexReader *m_tp_lexicon_reader;
   bool m_lexicon_read;
-  Vocabulary m_tp_vocabulary;
-  TokenPassSearch m_tp_search;
+  Vocabulary *m_tp_vocabulary;
+  TokenPassSearch *m_tp_search;
   
   Acoustics *m_acoustics;
-  LnaReaderCircular m_lna_reader;
+  LnaReaderCircular *m_lna_reader;
   OneFrameAcoustics m_one_frame_acoustics;
 
   std::string m_word_boundary;
@@ -370,9 +372,9 @@ private:
   std::deque<int> m_history;
   NGram *m_lookahead_ngram;
 
-  Expander m_expander;
+  Expander *m_expander;
 
-  Search m_search;
+  Search *m_search;
 
   LMHistory *m_last_guaranteed_history;
 };

--- a/decoder/src/swig/Decoder.i
+++ b/decoder/src/swig/Decoder.i
@@ -17,6 +17,9 @@ using namespace fsalm;
     std::cerr << e.what() << std::endl;
     SWIG_exception(SWIG_RuntimeError, "Exception");
   }
+  catch (...){
+    SWIG_exception(SWIG_RuntimeError, "Unknown exception received by swig");
+  }
 }
 
 #ifdef SWIGPYTHON
@@ -148,6 +151,7 @@ public:
   bool run();
   bool runto(int frame);
 	bool recognize_segment(int start_frame, int end_frame);
+  void reinitialize_search();
 
   int frame();
   int first_frame();


### PR DESCRIPTION
Fixes various memleaks, the decoder should run cleanly in valgrind now. Also makes it possible to reinitialize Toolbox without rereading the acoustic models.

IMPORTANT: The interface to use the decoder has a change - You have to call reinitialize_search() after reading the acoustic models and before setting any parameters. The python files in the decoder directory should show, what needs to be changed. You might also somehow bake the reading of the ph and dur files into the Toolbox constructor so that the reinitialize_search() could be automatically called there. I didn't make that change since I don't really know what you want to do.
