### PR TITLE
Lookahead fixes

### DIFF
--- a/decoder/src/HTKLatticeGrammar.cc
+++ b/decoder/src/HTKLatticeGrammar.cc
@@ -130,6 +130,9 @@ void HTKLatticeGrammar::read(FILE *file, bool binary) {
   }
   /*fprintf(stdout,"sidx %d, eidx %d, nidx %d\n", m_start_node_idx,
     m_end_node_idx, m_null_idx);*/
+  
+  // For lookahead
+  pregenerate_bigram_idxlist();
 }
 
 void HTKLatticeGrammar::write(FILE *file, bool binary) {
@@ -158,17 +161,17 @@ bool HTKLatticeGrammar::match_begin(const Gram &g) {
     std::vector<int> &cur_states = active_states[cur_token_num%2];
     std::vector<int> &new_states = active_states[(cur_token_num+1)%2];
 
-    //fprintf(stdout,"Active nodes:\n");
+#if 0
+    fprintf(stdout,"Active nodes:\n");
     for (int i=0;i<cur_states.size();i++) {
-      //fprintf(stdout,"%d (",cur_states[i]);
+      fprintf(stdout,"%d (",cur_states[i]);
       Node n = m_nodes[cur_states[i]];
       for (int j=0;j<n.arcs_out.size(); j++) {
-	//fprintf(stdout,"%d ", n.arcs_out[j]);
+	fprintf(stdout,"%d ", n.arcs_out[j]);
       }
-      //fprintf(stdout,")\n");
+      fprintf(stdout,")\n");
     }
-
-
+#endif
 
     if (cur_states.size()==0) return false;
     new_states.clear();
@@ -213,4 +216,51 @@ bool HTKLatticeGrammar::match_begin(const std::string &string_in) {
   }
 
   return match_begin(g);
+}
+
+void HTKLatticeGrammar::pregenerate_bigram_idxlist() {
+  m_bigram_idxlist.clear();
+  m_bigram_idxlist.resize(m_words.size());
+
+  int null_idx = word_index("!NULL");
+
+  for (std::vector<Arc>::iterator abeg=m_arcs.begin(); abeg!=m_arcs.end(); ++abeg) {
+    if (abeg->widx == null_idx) continue;
+    //fprintf(stderr, "Gen for (%s %d):\n", word(abeg->widx).c_str(), abeg->widx);
+    std::vector<int> &target_arclist = m_nodes[abeg->target].arcs_out;
+    std::set<int> &bigram_targetset = m_bigram_idxlist.at(abeg->widx);
+    for (std::vector<int>::iterator atarget=target_arclist.begin();
+         atarget!=target_arclist.end(); ++atarget) {
+      Arc *target = &m_arcs[*atarget];
+
+      // Skip NULL nodes
+      while (target->widx == null_idx) {
+        Node nextnode = m_nodes[target->target];
+        assert(nextnode.arcs_out.size()==1);
+        target = &(m_arcs[nextnode.arcs_out[0]]);
+      }
+      //fprintf(stderr, " (%s %d)", word(target->widx).c_str(), target->widx);
+      bigram_targetset.insert(target->widx);
+    }
+    //fprintf(stderr,"\n");
+  }
+}
+
+
+void HTKLatticeGrammar::fetch_bigram_list(int prev_word_id, 
+                                          std::vector<float> &result_buffer) {
+  result_buffer.resize(m_words.size());
+  for (std::vector<float>::iterator it=result_buffer.begin(); it!=result_buffer.end(); ++it) {
+    *it = IMPOSSIBLE_LOGPROB;
+  }
+
+  std::set<int> &possible_targets = m_bigram_idxlist[prev_word_id];
+  //fprintf(stderr, "%ld possible LA continuations for %s:", m_bigram_idxlist[prev_word_id].size(), 
+  //        word(prev_word_id).c_str());
+  for (std::set<int>::iterator idx = possible_targets.begin();
+       idx != possible_targets.end(); ++idx) {
+    //fprintf(stderr, " %d", *idx);
+    result_buffer[*idx] = 0.0f;
+  }
+  //fprintf(stderr, "\n");
 }

--- a/decoder/src/HTKLatticeGrammar.hh
+++ b/decoder/src/HTKLatticeGrammar.hh
@@ -3,6 +3,9 @@
 
 #include <stdio.h>
 #include "NGram.hh"
+#include <set>
+
+#define IMPOSSIBLE_LOGPROB -10000
 
 /* We inherit the interface to NGram for simplicity. Internally,
    this class has nothing to do with n-grams.
@@ -25,7 +28,7 @@ public:
     for (int i=0; i<gram.size();i++) 
       g.push_back(gram[i]);
     if (match_begin(g)) return 0;
-    return -60;
+    return IMPOSSIBLE_LOGPROB;
   };
 
   inline float log_prob_i(const std::vector<int> &gram) {assert(false);return 0;};
@@ -35,14 +38,14 @@ public:
     for (int i=0; i<gram.size();i++) 
       g.push_back(gram[i]);
     if (match_begin(g)) return 0;
-    return -60;
+    return IMPOSSIBLE_LOGPROB;
   };
 
   float log_prob_i(const std::vector<unsigned short> &gram){assert(false);return 0;};
 
   float log_prob_bo(const Gram &gram){
     if (match_begin(gram)) return 0;
-    return -60;
+    return IMPOSSIBLE_LOGPROB;
   }; 
   float log_prob_i(const Gram &gram){assert(false);return 0;};
 
@@ -50,9 +53,7 @@ public:
 
   /* These are for lookaheads, not implemented */
   void fetch_bigram_list(int prev_word_id, 
-			 std::vector<float> &result_buffer) {
-    assert(false);
-  }
+			 std::vector<float> &result_buffer);
   void fetch_trigram_list(int w1, int w2, 
 			  std::vector<float> &result_buffer) {
     assert(false);
@@ -81,5 +82,9 @@ private:
   int m_start_node_idx, m_end_node_idx, m_null_idx;
   
   bool match_begin(const Gram &g);
+
+  // This table is for LM lookahead and lists all allowable bigrams
+  std::vector<std::set<int> > m_bigram_idxlist;
+  void pregenerate_bigram_idxlist();
 };
 #endif

--- a/decoder/src/InterTreeGram.cc
+++ b/decoder/src/InterTreeGram.cc
@@ -90,6 +90,7 @@ void InterTreeGram::fetch_bigram_list(int prev_word_id,
   /* This may be too slow for real use */
 
   // Zero the result buffer
+  result_buffer.resize(m_words.size());
   for (std::vector<float>::iterator it=result_buffer.begin(); it!=result_buffer.end(); ++it) {
     *it = 0.0f;
   }


### PR DESCRIPTION
Added missing memory reservations for interpolated lookahead models. Also added pseudo-lookahead for htk lattice grammars (needed to keep the token count sensible in large lattices). The lattices could be handled more elegantly by actually building the grammar network in the decoder, but this improves the current quick-and-dirty solution.
