### PR TITLE
Fix decoder running out of tokens

### DIFF
--- a/decoder/src/TokenPassSearch.cc
+++ b/decoder/src/TokenPassSearch.cc
@@ -1032,7 +1032,11 @@ TokenPassSearch::move_token_to_node(TPLexPrefixTree::Token *token,
       // Add duration probability
       int temp_dur = token->dur + 1;
       duration_log_prob = m_duration_scale
-        * token->node->state->duration.get_log_prob(temp_dur);
+        // FIXME: -10.0f is for escaping long noisy silences without crashing. 
+        // it should be jus a bit higher than the global beam to allow
+        // escaping from insanely long phoneme
+        * std::max(token->node->state->duration.get_log_prob(temp_dur), -10.0f);
+
       updated_token.am_log_prob += duration_log_prob;
     }
 

--- a/decoder/src/TokenPassSearch.cc
+++ b/decoder/src/TokenPassSearch.cc
@@ -1032,10 +1032,10 @@ TokenPassSearch::move_token_to_node(TPLexPrefixTree::Token *token,
       // Add duration probability
       int temp_dur = token->dur + 1;
       duration_log_prob = m_duration_scale
-        // FIXME: -10.0f is for escaping long noisy silences without crashing. 
+        // FIXME: -5.0f is for escaping long noisy silences without crashing. 
         // it should be jus a bit higher than the global beam to allow
         // escaping from insanely long phoneme
-        * std::max(token->node->state->duration.get_log_prob(temp_dur), -10.0f);
+        * std::max(token->node->state->duration.get_log_prob(temp_dur), -5.0f);
 
       updated_token.am_log_prob += duration_log_prob;
     }

--- a/decoder/src/TokenPassSearch.hh
+++ b/decoder/src/TokenPassSearch.hh
@@ -578,6 +578,7 @@ public:
 private:
   TPLexPrefixTree &m_lexicon;
   Vocabulary &m_vocabulary;
+  int m_long_duration_pass;
 #ifdef ENABLE_WORDCLASS_SUPPORT
   const WordClasses * m_word_classes;
 #endif


### PR DESCRIPTION
With long noisy silences, the decoder may first prune all silence paths, leaving only phonemes with duration models. Later, MAX_STATE_DURATION removes theses tokens and decoder asserts(false). Happens only in rare cases.

This patch is an ugly fix, keeping at least 10 tokens with long durations alive and flooring the duration_prob so that it is still possible to exit the state through exit transition (otherwise will only self-transition).
