### PR TITLE
Set acoustic model before loading speaker config in align

### DIFF
--- a/aku/align.cc
+++ b/aku/align.cc
@@ -241,6 +241,7 @@ main(int argc, char *argv[])
     // Load speaker configurations
     if (config["speakers"].specified)
     {
+      speaker_config.get_model_transformer().set_model(&model);
       speaker_config.read_speaker_file(
         io::Stream(config["speakers"].get_str()));
       set_speakers = true;


### PR DESCRIPTION
Makes it possible to use model-based CMLLR also in conjunction with align.
