### PR TITLE
Recognizer to produce structured output vectors.

### DIFF
--- a/decoder/src/Toolbox.cc
+++ b/decoder/src/Toolbox.cc
@@ -489,6 +489,33 @@ Toolbox::init(int expand_window)
   m_search->init_search(expand_window);
 }
 
+const std::vector<timed_token_type>& Toolbox::best_timed_hypo_string(bool print_all){
+  HistoryVector hist_vec;
+  static std::vector<timed_token_type> retval;
+  retval.clear();
+
+  m_tp_search->get_path(hist_vec, print_all, print_all ? NULL : m_last_guaranteed_history);
+  bool all_guaranteed = true;
+  
+  for (int i = hist_vec.size() - 1; i >= 0; i--) {
+    std::string newstring("");
+    LMHistory *hist = hist_vec[i];
+    assert(hist->reference_count > 0);
+    if (hist->previous->reference_count == 1) {
+      if (all_guaranteed)
+        m_last_guaranteed_history = hist;
+    }
+    else {
+      if (all_guaranteed)
+        newstring = "* ";
+      all_guaranteed = false;
+    }
+
+    newstring += word(hist->last().word_id());
+    retval.push_back(timed_token_type(newstring,pair<double,double>(hist->word_start_frame,hist->word_first_silence_frame)));
+  }
+  return retval;
+}
 const bytestype& Toolbox::best_hypo_string(bool print_all, bool output_time) {
   HistoryVector hist_vec;
   static std::string retval;

--- a/decoder/src/Toolbox.hh
+++ b/decoder/src/Toolbox.hh
@@ -16,6 +16,8 @@
 #include "OneFrameAcoustics.hh"
 
 typedef std::string bytestype;
+typedef std::pair<std::string,std::pair<double,double> > timed_token_type;
+typedef std::vector<timed_token_type> timed_token_stream_type;
 
 class Toolbox {
 public:
@@ -171,6 +173,7 @@ public:
   void prune(int frame, int top);
   int paths() const { return HypoPath::g_count; }
 
+  const timed_token_stream_type &best_timed_hypo_string(bool print_all);
   const bytestype &best_hypo_string(bool print_all, bool output_time);
 
   // Options


### PR DESCRIPTION
Previously speech recognition result time values were embedded to the recognition stream with <time>-tags. This commit adds support for producing structured speech recognition output through the swig-interface. The resulting structured stream is a vector of pairs of morphs and start and end time pair values:
using namespace std;
typedef vector<pair<string,pair<double,double> > > timed_token_stream_type;
This structure can be read from python as a list of dictionaries with token, start and endtimes
[{'token', 'starttime', 'endtime'}]
using the "const timed_token_stream_type &best_timed_hypo_string(bool print_all);"-function
