### PR TITLE
fix broken build dependecy for aku swig

### DIFF
--- a/aku/swig/CMakeLists.txt
+++ b/aku/swig/CMakeLists.txt
@@ -11,13 +11,30 @@ set_source_files_properties(PPToolbox.i PROPERTIES CPLUSPLUS ON)
 swig_add_module(PPToolbox python PPToolbox.i)
 swig_link_libraries(PPToolbox ${PYTHON_LIBRARIES} aku)
 
-add_custom_target(TmpCWrap mv ${swig_generated_file_fullname} tmp.cxx 
-  DEPENDS "${swig_generated_file_fullname}"
-  COMMENT "mv ${swig_generated_file_fullname} tmp.cxx")
-add_custom_target(FixDefs python ${CMAKE_CURRENT_SOURCE_DIR}/add_undefs.py < tmp.cxx > ${swig_generated_file_fullname}
-  DEPENDS TmpCWrap
+# Override the standard cmake swig generator to create tmp file that
+# we can later fix
+add_custom_command(
+  OUTPUT "${swig_generated_file_fullname}.tmp"
+  # Let's create the ${swig_outdir} at execution time, in case dir contains $(OutDir)
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${swig_outdir}
+  COMMAND "${SWIG_EXECUTABLE}"
+  ARGS -python
+  ${swig_source_file_flags}
+  ${CMAKE_SWIG_FLAGS}
+  -outdir ${swig_outdir}
+  ${swig_special_flags}
+  ${swig_extra_flags}
+  ${swig_include_dirs}
+  -o "${swig_generated_file_fullname}.tmp"
+  "${swig_source_file_fullname}"
+  MAIN_DEPENDENCY "${swig_source_file_fullname}"
+  DEPENDS ${SWIG_MODULE_${name}_EXTRA_DEPS}
+  COMMENT "Swig source")
+
+add_custom_target(FixDefs python ${CMAKE_CURRENT_SOURCE_DIR}/add_undefs.py < ${swig_generated_file_fullname}.tmp > ${swig_generated_file_fullname}
+  OUTPUT "${swig_generated_file_fullname}"
+  DEPENDS ${swig_generated_file_fullname}.tmp
   COMMENT "Fixing defs for conflicting symbols in lapack and python")
-add_dependencies(${SWIG_MODULE_PPToolbox_REAL_NAME} FixDefs) 
 
 install(
 TARGETS ${SWIG_MODULE_PPToolbox_REAL_NAME}


### PR DESCRIPTION
If you have had weird dependency problems (need to delete build/aku/swig -directory after changing function arguments), this should fix it. Not very well tested yet.
